### PR TITLE
Adds additional handling around ScriptArgs to be more flexible

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -216,9 +216,7 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-$CakeArgs
 $exec ="& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $CakeArgs"
-$exec
 Write-Verbose $exec
 Invoke-Expression $exec
 exit $LASTEXITCODE


### PR DESCRIPTION
This is more of a request for comments, but I think it is a step in the right direction. Currently passing in parameters to a cake script from the powershell bootstrapper isn't consistent, plus kind of weird especially with handling filenames. 

Let's take this "build" script

```

#addin "Cake.FileHelpers"

var target = Argument("target", "Default");
var file = Argument<string>("file");
var someBool = Argument<bool>("someBool", true);
var someString =Argument<string>("someString", "hello!");

Task("Do-the-do")
    .Does(() =>
{
    Information("Bool value? {0}", someBool.ToString());
    Information("someString? {0}", someString);
    var exists = FileExists(file).ToString();
    Information("File {0} exists? {1}", file, exists);    
});

Task("Default")
    .IsDependentOn("Do-the-do");

RunTarget(target);
```

With the current implementation to run this script with diagnostic verbosity you must run to get this to work (note no equal after verbosity but required for the others)

```
.\build.ps1 -verbosity diagnostic -file="""file.txt""" -someBool=true
```

Additionally, if you make any mistake it'll blindly pass those args in cake giving some less than helpful errors because cake expects things differently than the bootstrapper. Some of these error messages actually point you in the wrong direction (see the verbosity help that is outputted)

```
 .\build.ps1 -verbosity=diagnostic -file="""file.txt"""
```

you get this output

```
Preparing to run build script...
Running build script...
Multiple arguments with the same name (verbosity).
Module directory does not exist.

Usage: Cake.exe [script] [--verbosity=value]
            [--showdescription] [--dryrun] [..]

Example: Cake.exe
Example: Cake.exe build.cake --verbosity=quiet
```

Or if you don't properly quote the file name 

```
.\build.ps1 -verbosity diagnostic -file=file.txt
```

you get this output

```
Preparing to run build script...
Running build script...
More than one build script specified.
Module directory does not exist.
```

This change allows you to run

```
.\build.ps1 -verbosity diagnostic -file file.txt -someBool
```

Looks more like powershell and still sends things into cake.exe as expected. `File.txt` will be properly quoted and `someBool` will be sent as `someBool=true`. Not sure if I've caught all the edge cases here especially around what values need to be quoted, but I wanted to throw this out and see what you all think. I'll be away on holiday until the 1st but hopefully I'll be able to check in and answer any questions or get tweaks implemented if this is something valuable. 
