### PR TITLE
Fixed issues when bootstrapper is ran from a path containing spaces.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ fi
 
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
-if [ ! -f $PACKAGES_CONFIG_MD5 ] || [ "$( cat $PACKAGES_CONFIG_MD5 | sed 's/\r$//' )" != "$( $MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' )" ]; then
+if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat \"$PACKAGES_CONFIG_MD5\" | sed 's/\r$//' )" != "$( $MD5_EXE \"$PACKAGES_CONFIG\" | awk '{ print $1 }' )" ]; then
     find . -type d ! -name . | xargs rm -rf
 fi
 
@@ -83,7 +83,7 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-$MD5_EXE $PACKAGES_CONFIG | awk '{ print $1 }' >| $PACKAGES_CONFIG_MD5
+$MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' >| "$PACKAGES_CONFIG_MD5"
 
 popd >/dev/null
 


### PR DESCRIPTION
When ran from a path that contains spaces e.g. "/home/user/random path/" the script runs into issues around line 76 i.e:

```
build.sh: line 76: [: /home/user/random: binary operator expected
cat: /home/user/random: No such file or directory
```

The fix is to provide quotes around paths that may contain spaces. Same fix as https://github.com/cake-build/bootstrapper/pull/21. 😄 