### PR TITLE
Removed quote escaping within command substitution

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -73,7 +73,7 @@ fi
 
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
-if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat \"$PACKAGES_CONFIG_MD5\" | sed 's/\r$//' )" != "$( $MD5_EXE \"$PACKAGES_CONFIG\" | awk '{ print $1 }' )" ]; then
+if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
     find . -type d ! -name . | xargs rm -rf
 fi
 


### PR DESCRIPTION
Tested with:

```
mkdir cake\ space
cd cake\ space

cat <<EOF >> build.cake
var target = Argument("target", "Default");

Task("Default")
  .Does(() =>
{
  Information("Hello World!");
});

RunTarget(target);
EOF

curl -Lsfo build.sh https://raw.githubusercontent.com/Silvenga/resources/QuoteAllPaths-Proper/build.sh
bash build.sh

bash build.sh
```