### PR TITLE
Adopt quoting to work in PowerShell 2 with targets containing a .

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: csharp
 script:
-  - echo "Information(Context.Environment.Runtime.CakeVersion.ToString());" > build.cake
+  - echo "Task(\"Default\").Does(() => {}); Task(\"Task.With.Dots\").Does(() => {}); RunTarget(Argument<string>(\"target\"));" > build.cake
+  - echo "Testing (Default task)"
   - ./build.sh || exit 1
+  - echo "Testing (Specific task)"
+  - ./build.sh --target Task.With.Dots || exit 1
   - echo "Testing with modules/addin packages.config"
   - mkdir tools/modules
   - echo -e "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<packages>\r\n    <package id=\"Cake.Paket.Module\" version=\"1.2.2\" />\r\n</packages>" > ./tools/modules/packages.config

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,15 +1,23 @@
 version: 1.0.{build}
 build_script:
 - ps: >-
-    'Information("Test success: {0}", DateTime.Now);' > build.cake
+    'Task("Default").Does(() => {}); Task("Task.With.Dots").Does(() => {}); RunTarget(Argument<string>("target"));' > build.cake
 
-    'Testing with PowerShell Current'
+    'Testing with PowerShell Current (Default task)'
 
     ./build.ps1
 
-    'Testing with PowerShell V2'
+    'Testing with PowerShell Current (Specific task)'
+
+    ./build.ps1 -target Task.With.Dots
+
+    'Testing with PowerShell V2 (Default task)'
 
     PowerShell.exe -Version 2.0 -File .\build.ps1
+
+    'Testing with PowerShell V2 (Specific task)'
+
+    PowerShell.exe -Version 2.0 -File .\build.ps1 -target Task.With.Dots
 
     New-Item -ItemType Directory ./tools/modules
 

--- a/build.ps1
+++ b/build.ps1
@@ -224,5 +224,5 @@ if (!(Test-Path $CAKE_EXE)) {
 
 # Start Cake
 Write-Host "Running build script..."
-Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" -target=`"$Target`" -configuration=`"$Configuration`" -verbosity=`"$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
+Invoke-Expression "& `"$CAKE_EXE`" `"$Script`" `"-target=$Target`" `"-configuration=$Configuration`" `"-verbosity=$Verbosity`" $UseMono $UseDryRun $UseExperimental $ScriptArgs"
 exit $LASTEXITCODE


### PR DESCRIPTION
The current version of the bootstrapper fails while running in PowerShell 2 if a target containing a `.` in its name is passed (eg. `.\build.ps1 -target foo.bar`).