### PR TITLE
Sync with Cake args, smarter defaults

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,24 +28,14 @@ fi
 
 # Define default arguments.
 SCRIPT="build.cake"
-TARGET="Default"
-CONFIGURATION="Release"
-VERBOSITY="verbose"
-DRYRUN=
-SHOW_VERSION=false
-SCRIPT_ARGUMENTS=()
+CAKE_ARGUMENTS=()
 
 # Parse arguments.
 for i in "$@"; do
     case $1 in
         -s|--script) SCRIPT="$2"; shift ;;
-        -t|--target) TARGET="$2"; shift ;;
-        -c|--configuration) CONFIGURATION="$2"; shift ;;
-        -v|--verbosity) VERBOSITY="$2"; shift ;;
-        -d|--dryrun) DRYRUN="-dryrun" ;;
-        --version) SHOW_VERSION=true ;;
-        --) shift; SCRIPT_ARGUMENTS+=("$@"); break ;;
-        *) SCRIPT_ARGUMENTS+=("$1") ;;
+        --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
+        *) CAKE_ARGUMENTS+=("$1") ;;
     esac
     shift
 done
@@ -124,8 +114,4 @@ if [ ! -f "$CAKE_EXE" ]; then
 fi
 
 # Start Cake
-if $SHOW_VERSION; then
-    exec mono "$CAKE_EXE" -version
-else
-    exec mono "$CAKE_EXE" $SCRIPT -verbosity=$VERBOSITY -configuration=$CONFIGURATION -target=$TARGET $DRYRUN "${SCRIPT_ARGUMENTS[@]}"
-fi
+exec mono "$CAKE_EXE" $SCRIPT "${CAKE_ARGUMENTS[@]}"


### PR DESCRIPTION
All scripts should continue running the same as they have, but this opens some new doors.
I think I found a really cool solution for existing headaches. Would you mind taking a look and seeing if these things are doable? 


#### Smarter defaults

 * If no target is specified, sends nothing to cake.exe instead of sending `--target="Default"`.
* If no configuration is specified, sends nothing to cake.exe instead of sending `--configuration="Release"`.
* If no verbosity is specified, sends nothing to cake.exe instead of sending `--verbosity="Verbose"`.

 This allows you to set your own defaults by using `Argument("Target", "something-other-than-Default")`, `Argument("Configuration", "something-other-than-Release")`, `Argument("Verbosity", "something-other-than-Verbose")` in your build scripts.

Also, it prevents this kind of error from showing up if you use `=` which the bootstrapper does not recognize but cake.exe does, e.g. `-configuration=Debug`:

> Multiple arguments with the same name (configuration).

#### Fixes configuration validation

<s>Retains tab completion</s> without preventing you from using configurations other than `Debug` and `Release`.


#### Syncs with Cake arguments

 * Adds `-showdescription`
 * Rotates the aliases `-DryRun` and `-WhatIf` to match cake.exe
 * Updates .PARAMETER descriptions to match cake.exe
 * Sorts parameters to match cake.exe