### PR TITLE
Fixes bash script failing to parse space-separated or single-letter argument values

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,6 +34,10 @@ CAKE_ARGUMENTS=()
 for i in "$@"; do
     case $1 in
         -s|--script) SCRIPT="$2"; shift ;;
+        -t|--target) CAKE_ARGUMENTS+=("--target=$2"); shift ;;
+        -c|--configuration) CAKE_ARGUMENTS+=("--configuration=$2"); shift ;;
+        -v|--verbosity) CAKE_ARGUMENTS+=("--verbosity=$2"); shift ;;
+        -d) CAKE_ARGUMENTS+=("--dryrun") ;;
         --) shift; CAKE_ARGUMENTS+=("$@"); break ;;
         *) CAKE_ARGUMENTS+=("$1") ;;
     esac


### PR DESCRIPTION
Fixes https://github.com/cake-build/resources/issues/33 (might be a good idea not to take my word for it 😈)

We need to add tests for this, but I put this up for early review so that we can possibly publish the fix to everyone sooner than that.