### PR TITLE
build.sh removes Modules folder

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -158,8 +158,11 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
       ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
         Write-Verbose -Message "Missing or changed package.config hash..."
-        Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
-        Remove-Item -Recurse
+        Get-ChildItem -Recurse -Exclude packages.config,nuget.exe,Cake.Bakery |
+        Select-Object -ExpandProperty FullName |
+        Where-Object {($_ -notlike '*\Modules') -and ($_ -notlike '*\Addins')} |
+        Sort-Object length -Descending |
+        Remove-Item -force -Recurse
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ fi
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
 if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
-    find . -type d ! -name . ! -name 'Cake.Bakery' ! -name 'Modules' | xargs rm -rf
+    find . -type d ! -name . ! -name 'Cake.Bakery' ! -name 'Modules' ! -name 'Addins' | xargs rm -rf
 fi
 
 mono "$NUGET_EXE" install -ExcludeVersion

--- a/build.sh
+++ b/build.sh
@@ -68,7 +68,7 @@ fi
 # Restore tools from NuGet.
 pushd "$TOOLS_DIR" >/dev/null
 if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
-    find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
+    find . -type d ! -name . ! -name 'Cake.Bakery' ! -name 'Modules' | xargs rm -rf
 fi
 
 mono "$NUGET_EXE" install -ExcludeVersion


### PR DESCRIPTION
build.sh should not remove the whole Modules folder because it may contain the packages.config file.