### PR TITLE
Simplified powershell bootstrapper

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -29,8 +29,10 @@ Performs a dry run.
 Uses the nightly builds of the Roslyn script engine.
 .PARAMETER Mono
 Uses the Mono Compiler rather than the Roslyn script engine.
-.PARAMETER SkipToolPackageRestore
-Skips restoring of packages.
+.PARAMETER CakeVersion
+The Cake version to use when running the build script.
+.PARAMETER UseNetCore
+The the CORE CLR edition of Cake.
 .PARAMETER ScriptArgs
 Remaining arguments are added here.
 
@@ -51,32 +53,29 @@ Param(
     [switch]$DryRun,
     [switch]$Experimental,
     [switch]$Mono,
-    [switch]$SkipToolPackageRestore,
+    [version]$CakeVersion = '0.28.0',
+    [switch]$UseNetCore,
     [Parameter(Position=0,Mandatory=$false,ValueFromRemainingArguments=$true)]
     [string[]]$ScriptArgs
 )
 
-[Reflection.Assembly]::LoadWithPartialName("System.Security") | Out-Null
-function MD5HashFile([string] $filePath)
-{
-    if ([string]::IsNullOrEmpty($filePath) -or !(Test-Path $filePath -PathType Leaf))
-    {
-        return $null
-    }
+if (!(Test-Path Function:\Expand-Archive)) {
+    function Expand-Archive() {
+        param([string]$Path, [string]$DestinationPath)
 
-    [System.IO.Stream] $file = $null;
-    [System.Security.Cryptography.MD5] $md5 = $null;
-    try
-    {
-        $md5 = [System.Security.Cryptography.MD5]::Create()
-        $file = [System.IO.File]::OpenRead($filePath)
-        return [System.BitConverter]::ToString($md5.ComputeHash($file))
-    }
-    finally
-    {
-        if ($file -ne $null)
-        {
-            $file.Dispose()
+        if (!(Test-Path $DestinationPath)) { New-Item -Type Directory -Path $DestinationPath }
+
+        $isPowershellCore = $PSVersionTable -and $PSVersionTable.PSEdition -eq 'Core'
+        $haveNet45 = $PSVersionTable -and $PSVersionTable.CLRVersion -and ($PSVersionTable.CLRVersion -ge [version]'4.0.30319.17001')
+
+        if ($isPowershellCore -or $haveNet45) {
+            Add-Type -AssemblyName System.IO.Compression.FileSystem
+            [System.IO.Compression.ZipFile]::ExtractToDirectory($Path, $DestinationPath)
+        } else {
+            $shellApplication = New-Object -ComObject shell.application
+            $zipPackage = $shellApplication.namespace($Path)
+            $destinationFolder = $shellApplication.namespace($DestinationPath)
+            $destinationFolder.CopyHere($zipPackage.Items(), 16)
         }
     }
 }
@@ -90,146 +89,77 @@ function GetProxyEnabledWebClient
     return $wc
 }
 
-Write-Host "Preparing to run build script..."
-
-if(!$PSScriptRoot){
-    $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
-}
-
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
-$ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
-$MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
-$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
-$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
-$NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
-$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
-$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
-$ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
-$MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+$CAKE_EXE_DIR = ""
+if ($UseNetCore) {
+    $CAKE_DIR_NAME = "Cake.CoreCLR"
+} else {
+    $CAKE_DIR_NAME = "Cake"
+}
 
-# Make sure tools folder exists
+$CAKE_URL = "https://www.nuget.org/api/v2/package/$($CAKE_DIR_NAME)/$($CakeVersion)"
+
+if ($CakeVersion) {
+    $CAKE_EXE_DIR = Join-Path "$TOOLS_DIR" "$CAKE_DIR_NAME.$($CakeVersion.ToString())"
+} else {
+    $CAKE_EXE_DIR = Join-Path "$TOOLS_DIR" "$CAKE_DIR_NAME"
+}
+
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
-    Write-Verbose -Message "Creating tools directory..."
-    New-Item -Path $TOOLS_DIR -Type directory | out-null
+    Write-Verbose "Creating tools directory..."
+    New-Item -Path $TOOLS_DIR -Type Directory | Out-Null
 }
 
-# Make sure that packages.config exist.
-if (!(Test-Path $PACKAGES_CONFIG)) {
-    Write-Verbose -Message "Downloading packages.config..."    
-    try {        
-        $wc = GetProxyEnabledWebClient
-        $wc.DownloadFile("https://cakebuild.net/download/bootstrapper/packages", $PACKAGES_CONFIG) } catch {
-        Throw "Could not download packages.config."
-    }
-}
+if (!(Test-Path $CAKE_EXE_DIR)) {
+    # We download and save it as a normal zip file, in cases
+    # were we need to extract it using com.
+    $tmpDownloadFile = Join-Path "$TOOLS_DIR" "$CAKE_DIR_NAME.zip"
+    Write-Verbose "Downloading Cake package..."
 
-# Try find NuGet.exe in path if not exists
-if (!(Test-Path $NUGET_EXE)) {
-    Write-Verbose -Message "Trying to find nuget.exe in PATH..."
-    $existingPaths = $Env:Path -Split ';' | Where-Object { (![string]::IsNullOrEmpty($_)) -and (Test-Path $_ -PathType Container) }
-    $NUGET_EXE_IN_PATH = Get-ChildItem -Path $existingPaths -Filter "nuget.exe" | Select -First 1
-    if ($NUGET_EXE_IN_PATH -ne $null -and (Test-Path $NUGET_EXE_IN_PATH.FullName)) {
-        Write-Verbose -Message "Found in PATH at $($NUGET_EXE_IN_PATH.FullName)."
-        $NUGET_EXE = $NUGET_EXE_IN_PATH.FullName
-    }
-}
-
-# Try download NuGet.exe if not exists
-if (!(Test-Path $NUGET_EXE)) {
-    Write-Verbose -Message "Downloading NuGet.exe..."
     try {
         $wc = GetProxyEnabledWebClient
-        $wc.DownloadFile($NUGET_URL, $NUGET_EXE)
+        $wc.DownloadFile($CAKE_URL, $tmpDownloadFile)
     } catch {
-        Throw "Could not download NuGet.exe."
+        throw "Could not download Cake package...`n`nException:$_"
     }
+
+    Write-Verbose "Extracting Cake package..."
+    Expand-Archive -Path $tmpDownloadFile -DestinationPath $CAKE_EXE_DIR
+    Remove-Item -Recurse -Force $tmpDownloadFile,"$CAKE_EXE_DIR/_rels","$CAKE_EXE_DIR/``[Content_Types``].xml","$CAKE_EXE_DIR/package"
 }
 
-# Save nuget.exe path to environment to be available to child processed
-$ENV:NUGET_EXE = $NUGET_EXE
-
-# Restore tools from NuGet?
-if(-Not $SkipToolPackageRestore.IsPresent) {
-    Push-Location
-    Set-Location $TOOLS_DIR
-
-    # Check for changes in packages.config and remove installed tools if true.
-    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
-    if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
-      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
-        Write-Verbose -Message "Missing or changed package.config hash..."
-        Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
-        Remove-Item -Recurse
-    }
-
-    Write-Verbose -Message "Restoring tools from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
-
-    if ($LASTEXITCODE -ne 0) {
-        Throw "An error occurred while restoring NuGet tools."
-    }
-    else
-    {
-        $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
-    }
-    Write-Verbose -Message ($NuGetOutput | out-string)
-
-    Pop-Location
+if ($UseNetCore) {
+    $CAKE_EXE = Get-ChildItem -LiteralPath $CAKE_EXE_DIR -Filter "Cake.dll" -Recurse | Select-Object -First 1 -ExpandProperty FullName
+    if (!$CAKE_EXE) { throw "Unable to find the Cake.dll library" }
+} else {
+    $CAKE_EXE = Get-ChildItem -LiteralPath $CAKE_EXE_DIR -Filter "Cake.exe" -Recurse | Select-Object -First 1 -ExpandProperty FullName
+    if (!$CAKE_EXE) { throw "Unable to find the Cake.exe executable" }
 }
 
-# Restore addins from NuGet
-if (Test-Path $ADDINS_PACKAGES_CONFIG) {
-    Push-Location
-    Set-Location $ADDINS_DIR
+$cakeArguments = New-Object System.Collections.Generic.List[string]
+$cakeArguments.Add($Script) | Out-Null
+$excludeArgs = @("Script","CakeVersion","UseNetCore","ScriptArgs", "Verbose")
 
-    Write-Verbose -Message "Restoring addins from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
-
-    if ($LASTEXITCODE -ne 0) {
-        Throw "An error occurred while restoring NuGet addins."
+$PSBoundParameters.GetEnumerator() | ? { !$excludeArgs.Contains($_.Key) } | % {
+    if ($_.Value) {
+        $cakeArguments.Add("-$($_.Key)=$($_.Value)")
+    } else {
+        $cakeArguments.Add("-$($_.Key)")
     }
-
-    Write-Verbose -Message ($NuGetOutput | out-string)
-
-    Pop-Location
+} | Out-Null
+if ($ScriptArgs) {
+    $cakeArguments.AddRange($ScriptArgs) | Out-Null
 }
 
-# Restore modules from NuGet
-if (Test-Path $MODULES_PACKAGES_CONFIG) {
-    Push-Location
-    Set-Location $MODULES_DIR
-
-    Write-Verbose -Message "Restoring modules from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
-
-    if ($LASTEXITCODE -ne 0) {
-        Throw "An error occurred while restoring NuGet modules."
-    }
-
-    Write-Verbose -Message ($NuGetOutput | out-string)
-
-    Pop-Location
+if ($UseNetCore) {
+    $cakeArguments.Insert(0, $CAKE_EXE) | Out-Null
+    $CAKE_EXE = Get-Command -Name dotnet | ForEach-Object Definition
+} elseif ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    $cakeArguments.Insert(0, $CAKE_EXE) | Out-Null
+    $CAKE_EXE = Get-Command -Name mono | ForEach-Object Definition
 }
 
-# Make sure that Cake has been installed.
-if (!(Test-Path $CAKE_EXE)) {
-    Throw "Could not find Cake.exe at $CAKE_EXE"
-}
-
-
-
-# Build Cake arguments
-$cakeArguments = @("$Script");
-if ($Target) { $cakeArguments += "-target=$Target" }
-if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
-if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
-if ($ShowDescription) { $cakeArguments += "-showdescription" }
-if ($DryRun) { $cakeArguments += "-dryrun" }
-if ($Experimental) { $cakeArguments += "-experimental" }
-if ($Mono) { $cakeArguments += "-mono" }
-$cakeArguments += $ScriptArgs
-
-# Start Cake
 Write-Host "Running build script..."
-&$CAKE_EXE $cakeArguments
+Write-Verbose "Calling & $CAKE_EXE $cakeArguments"
+& $Cake_EXE $cakeArguments
 exit $LASTEXITCODE

--- a/build.ps1
+++ b/build.ps1
@@ -89,8 +89,11 @@ function GetProxyEnabledWebClient
     return $wc
 }
 
+if (!$PSScriptRoot) { $PSScriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition }
+
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $CAKE_EXE_DIR = ""
+
 if ($UseNetCore) {
     $CAKE_DIR_NAME = "Cake.CoreCLR"
 } else {


### PR DESCRIPTION
With this PR the bootstrapper no longer downloads the tools and no longer relies on a packages.config file.
As a bonus, this new bootstrapper also adds support for .NET Core.

This PR doesn't really fix any open issue, but is related to the following list of issues.
#53 #28 #21 #15

/CC @gep13 