### PR TITLE
Flow tools, addins and modules paths from the botstrapper to cake.exe

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ script:
   - echo "Information(Context.Environment.Runtime.CakeVersion.ToString());" > build.cake
   - ./build.sh || exit 1
   - echo "Testing with modules/addin packages.config"
-  - mkdir tools/modules
-  - echo -e "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<packages>\r\n    <package id=\"Cake.Chocolatey.Module\" version=\"0.5.0\" />\r\n</packages>" > ./tools/modules/packages.config
-  - mkdir tools/addins
-  - echo -e "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<packages>\r\n    <package id=\"Cake.MicrosoftTeams\" version=\"0.7.0\" />\r\n</packages>" > ./tools/addins/packages.config
+  - mkdir .cakebuild/modules
+  - echo -e "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<packages>\r\n    <package id=\"Cake.Chocolatey.Module\" version=\"0.5.0\" />\r\n</packages>" > ./.cakebuild/modules/packages.config
+  - mkdir .cakebuild/addins
+  - echo -e "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<packages>\r\n    <package id=\"Cake.MicrosoftTeams\" version=\"0.7.0\" />\r\n</packages>" > ./.cakebuild/addins/packages.config
   - ./build.sh || exit 1
   - ls -D -R
 os:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,13 +48,13 @@ build_script:
 
     'Creating Test Module Files'
 
-    New-Item -ItemType Directory ./tools/modules
+    New-Item -ItemType Directory ./.cakebuild/modules
 
-    "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.Chocolatey.Module"" version=""0.5.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/modules/packages.config
+    "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.Chocolatey.Module"" version=""0.5.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./.cakebuild/modules/packages.config
 
-    New-Item -ItemType Directory ./tools/addins
+    New-Item -ItemType Directory ./.cakebuild/addins
 
-    "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.MicrosoftTeams"" version=""0.7.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/addins/packages.config
+    "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.MicrosoftTeams"" version=""0.7.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./.cakebuild/addins/packages.config
 
 
     'Testing with PowerShell Module & Addin restore'

--- a/build.ps1
+++ b/build.ps1
@@ -104,21 +104,21 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
-$TOOLS_DIR = Join-Path $PSScriptRoot "tools"
-$ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
-$MODULES_DIR = Join-Path $TOOLS_DIR "Modules"
-$NUGET_EXE = Join-Path $TOOLS_DIR "nuget.exe"
-$CAKE_EXE = Join-Path $TOOLS_DIR "Cake/Cake.exe"
+$env:CAKE_PATHS_TOOLS = Join-Path $PSScriptRoot ".cakebuild"
+$env:CAKE_PATHS_ADDINS = Join-Path $env:CAKE_PATHS_TOOLS "Addins"
+$env:CAKE_PATHS_MODULES = Join-Path $env:CAKE_PATHS_TOOLS "Modules"
+$NUGET_EXE = Join-Path $env:CAKE_PATHS_TOOLS "nuget.exe"
+$CAKE_EXE = Join-Path $env:CAKE_PATHS_TOOLS "Cake/Cake.exe"
 $NUGET_URL = "https://dist.nuget.org/win-x86-commandline/latest/nuget.exe"
-$PACKAGES_CONFIG = Join-Path $TOOLS_DIR "packages.config"
-$PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
-$ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
-$MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
+$PACKAGES_CONFIG = Join-Path $env:CAKE_PATHS_TOOLS "packages.config"
+$PACKAGES_CONFIG_MD5 = Join-Path $env:CAKE_PATHS_TOOLS "packages.config.md5sum"
+$ADDINS_PACKAGES_CONFIG = Join-Path $env:CAKE_PATHS_ADDINS "packages.config"
+$MODULES_PACKAGES_CONFIG = Join-Path $env:CAKE_PATHS_MODULES "packages.config"
 
-# Make sure tools folder exists
-if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
+# Make sure CakeBuild folder exists
+if ((Test-Path $PSScriptRoot) -and !(Test-Path $env:CAKE_PATHS_TOOLS)) {
     Write-Verbose -Message "Creating tools directory..."
-    New-Item -Path $TOOLS_DIR -Type directory | out-null
+    New-Item -Path $env:CAKE_PATHS_TOOLS -Type directory | out-null
 }
 
 # Make sure that packages.config exist.
@@ -160,7 +160,7 @@ $ENV:NUGET_EXE = $NUGET_EXE
 # Restore tools from NuGet?
 if(-Not $SkipToolPackageRestore.IsPresent) {
     Push-Location
-    Set-Location $TOOLS_DIR
+    Set-Location $env:CAKE_PATHS_TOOLS
 
     # Check for changes in packages.config and remove installed tools if true.
     [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
@@ -172,7 +172,7 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$env:CAKE_PATHS_TOOLS`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occurred while restoring NuGet tools."
@@ -189,10 +189,10 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
 # Restore addins from NuGet
 if (Test-Path $ADDINS_PACKAGES_CONFIG) {
     Push-Location
-    Set-Location $ADDINS_DIR
+    Set-Location $env:CAKE_PATHS_ADDINS
 
     Write-Verbose -Message "Restoring addins from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$env:CAKE_PATHS_ADDINS`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occurred while restoring NuGet addins."
@@ -206,10 +206,10 @@ if (Test-Path $ADDINS_PACKAGES_CONFIG) {
 # Restore modules from NuGet
 if (Test-Path $MODULES_PACKAGES_CONFIG) {
     Push-Location
-    Set-Location $MODULES_DIR
+    Set-Location $env:CAKE_PATHS_MODULES
 
     Write-Verbose -Message "Restoring modules from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
+    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$env:CAKE_PATHS_MODULES`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occurred while restoring NuGet modules."
@@ -238,5 +238,5 @@ $cakeArguments += $ScriptArgs
 
 # Start Cake
 Write-Host "Running build script..."
-&$CAKE_EXE $cakeArguments
+&$CAKE_EXE $cakeArguments --paths_tools=$env:CAKE_PATHS_TOOLS
 exit $LASTEXITCODE

--- a/build.sh
+++ b/build.sh
@@ -8,15 +8,15 @@
 
 # Define directories.
 SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
-TOOLS_DIR=$SCRIPT_DIR/tools
-ADDINS_DIR=$TOOLS_DIR/Addins
-MODULES_DIR=$TOOLS_DIR/Modules
-NUGET_EXE=$TOOLS_DIR/nuget.exe
-CAKE_EXE=$TOOLS_DIR/Cake/Cake.exe
-PACKAGES_CONFIG=$TOOLS_DIR/packages.config
-PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
-ADDINS_PACKAGES_CONFIG=$ADDINS_DIR/packages.config
-MODULES_PACKAGES_CONFIG=$MODULES_DIR/packages.config
+export CAKE_PATHS_TOOLS=$SCRIPT_DIR/.cakebuild
+export CAKE_PATHS_ADDINS=$CAKE_PATHS_TOOLS/Addins
+export CAKE_PATHS_MODULES=$CAKE_PATHS_TOOLS/Modules
+NUGET_EXE=$CAKE_PATHS_TOOLS/nuget.exe
+CAKE_EXE=$CAKE_PATHS_TOOLS/Cake/Cake.exe
+PACKAGES_CONFIG=$CAKE_PATHS_TOOLS/packages.config
+PACKAGES_CONFIG_MD5=$CAKE_PATHS_TOOLS/packages.config.md5sum
+ADDINS_PACKAGES_CONFIG=$CAKE_PATHS_ADDINS/packages.config
+MODULES_PACKAGES_CONFIG=$CAKE_PATHS_MODULES/packages.config
 
 # Define md5sum or md5 depending on Linux/OSX
 MD5_EXE=
@@ -41,14 +41,14 @@ for i in "$@"; do
 done
 
 # Make sure the tools folder exist.
-if [ ! -d "$TOOLS_DIR" ]; then
-  mkdir "$TOOLS_DIR"
+if [ ! -d "$CAKE_PATHS_TOOLS" ]; then
+  mkdir "$CAKE_PATHS_TOOLS"
 fi
 
 # Make sure that packages.config exist.
-if [ ! -f "$TOOLS_DIR/packages.config" ]; then
+if [ ! -f "$CAKE_PATHS_TOOLS/packages.config" ]; then
     echo "Downloading packages.config..."
-    curl -Lsfo "$TOOLS_DIR/packages.config" https://cakebuild.net/download/bootstrapper/packages
+    curl -Lsfo "$CAKE_PATHS_TOOLS/packages.config" https://cakebuild.net/download/bootstrapper/packages
     if [ $? -ne 0 ]; then
         echo "An error occurred while downloading packages.config."
         exit 1
@@ -66,7 +66,7 @@ if [ ! -f "$NUGET_EXE" ]; then
 fi
 
 # Restore tools from NuGet.
-pushd "$TOOLS_DIR" >/dev/null
+pushd "$CAKE_PATHS_TOOLS" >/dev/null
 if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/\r$//' )" != "$( $MD5_EXE "$PACKAGES_CONFIG" | awk '{ print $1 }' )" ]; then
     find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
 fi
@@ -83,7 +83,7 @@ popd >/dev/null
 
 # Restore addins from NuGet.
 if [ -f "$ADDINS_PACKAGES_CONFIG" ]; then
-    pushd "$ADDINS_DIR" >/dev/null
+    pushd "$CAKE_PATHS_ADDINS" >/dev/null
 
     mono "$NUGET_EXE" install -ExcludeVersion
     if [ $? -ne 0 ]; then
@@ -96,7 +96,7 @@ fi
 
 # Restore modules from NuGet.
 if [ -f "$MODULES_PACKAGES_CONFIG" ]; then
-    pushd "$MODULES_DIR" >/dev/null
+    pushd "$CAKE_PATHS_MODULES" >/dev/null
 
     mono "$NUGET_EXE" install -ExcludeVersion
     if [ $? -ne 0 ]; then

--- a/cake.config
+++ b/cake.config
@@ -7,9 +7,9 @@ UseInProcessClient=true
 LoadDependencies=false
 
 [Paths]
-Tools=./tools
-Addins=./tools/Addins
-Modules=./tools/Modules
+Tools=./.cakebuild
+Addins=./.cakebuild/Addins
+Modules=./.cakebuild/Modules
 
 [Settings]
 SkipVerification=false


### PR DESCRIPTION
This change allows any change to the tools, addins or modules paths in the bootstrapper to flow to the invocation of cake.exe