### PR TITLE
build.sh: adding OutputDirectory command line argument to nuget commands

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -71,7 +71,7 @@ if [ ! -f "$PACKAGES_CONFIG_MD5" ] || [ "$( cat "$PACKAGES_CONFIG_MD5" | sed 's/
     find . -type d ! -name . ! -name 'Cake.Bakery' | xargs rm -rf
 fi
 
-mono "$NUGET_EXE" install -ExcludeVersion
+mono "$NUGET_EXE" install -ExcludeVersion -OutputDirectory "$TOOLS_DIR"
 if [ $? -ne 0 ]; then
     echo "Could not restore NuGet tools."
     exit 1
@@ -85,7 +85,7 @@ popd >/dev/null
 if [ -f "$ADDINS_PACKAGES_CONFIG" ]; then
     pushd "$ADDINS_DIR" >/dev/null
 
-    mono "$NUGET_EXE" install -ExcludeVersion
+    mono "$NUGET_EXE" install -ExcludeVersion -OutputDirectory "$ADDINS_DIR"
     if [ $? -ne 0 ]; then
         echo "Could not restore NuGet addins."
         exit 1
@@ -98,7 +98,7 @@ fi
 if [ -f "$MODULES_PACKAGES_CONFIG" ]; then
     pushd "$MODULES_DIR" >/dev/null
 
-    mono "$NUGET_EXE" install -ExcludeVersion
+    mono "$NUGET_EXE" install -ExcludeVersion -OutputDirectory "$MODULES_DIR"
     if [ $? -ne 0 ]; then
         echo "Could not restore NuGet modules."
         exit 1


### PR DESCRIPTION
Due to a missing "-OutputDirectory" command line argument (nuget commands) in the build.sh file (that is present in the build.ps1 file) the behavior of the two files is different if a Nuget.config file exists in the project folder.

see https://gitlab.com/tobiaskoch/LinkTime/-/jobs/122604224