### PR TITLE
Make build.ps1 cross-platform

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,13 @@
 version: 1.0.{build}
+
+image:
+- Visual Studio 2017
+- Ubuntu
+
 build_script:
 - ps: >-
+
+    [int] $Result = 0;
 
     # Temporarily skip verification and opt-in to new in-proc NuGet
 
@@ -17,9 +24,11 @@ build_script:
 
     $OutputA = ./build.ps1 2>&1
 
+    $Result = $LastExitCode
+
     $OutputA
 
-    if ($LastExitCode -ne 0)
+    if ($Result -ne 0)
 
     {
       'PowerShell 3 failed'
@@ -29,22 +38,27 @@ build_script:
 
 
 
+    if (-not $IsCoreCLR) {
 
-    'Testing with PowerShell V2'
+      'Testing with PowerShell V2'
 
-    $OutputB = PowerShell -Version 2.0 -File .\build.ps1 2>&1
+      $OutputB = PowerShell -Version 2.0 -File .\build.ps1 2>&1
 
-    $OutputB
+      $Result = $LastExitCode
 
-    if ($LastExitCode -ne 0)
+      $OutputB
 
-    {
-      'PowerShell 2 failed'
+      if ($Result -ne 0)
 
-      exit 2
+      {
+
+        'PowerShell 2 failed'
+
+        exit 2
+
+      }
+
     }
-
-
 
     'Creating Test Module Files'
 
@@ -61,14 +75,18 @@ build_script:
 
     $OutputC = ./build.ps1 2>&1
 
+    $Result = $LastExitCode
+
     $OutputC
 
-    if ($LastExitCode -ne 0)
+    if ($Result -ne 0)
 
     {
+
       'PowerShell Module failed'
 
       exit 2
+
     }
 
 

--- a/build.ps1
+++ b/build.ps1
@@ -59,7 +59,10 @@ try {
     # Use integers because the enumeration values for TLS 1.2 and TLS 1.1 won't
     # exist in .NET 4.0, even though they are addressable if .NET 4.5+ is
     # installed (.NET 4.5 is an in-place upgrade).
-    [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+    # PowerShell Core already has support for TLS 1.2 so we can skip this if running in that.
+    if (-not $IsCoreCLR) {
+        [System.Net.ServicePointManager]::SecurityProtocol = 3072 -bor 768 -bor 192 -bor 48
+    }
   } catch {
     Write-Output 'Unable to set PowerShell to use TLS 1.2 and TLS 1.1 due to old .NET Framework installed. If you see underlying connection closed or trust errors, you may need to upgrade to .NET Framework 4.5+ and PowerShell v3'
   }
@@ -118,7 +121,7 @@ $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
     Write-Verbose -Message "Creating tools directory..."
-    New-Item -Path $TOOLS_DIR -Type directory | out-null
+    New-Item -Path $TOOLS_DIR -Type Directory | Out-Null
 }
 
 # Make sure that packages.config exist.
@@ -155,7 +158,12 @@ if (!(Test-Path $NUGET_EXE)) {
 }
 
 # Save nuget.exe path to environment to be available to child processed
-$ENV:NUGET_EXE = $NUGET_EXE
+$env:NUGET_EXE = $NUGET_EXE
+$env:NUGET_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
+    "mono `"$NUGET_EXE`""
+} else {
+    "`"$NUGET_EXE`""
+}
 
 # Restore tools from NuGet?
 if(-Not $SkipToolPackageRestore.IsPresent) {
@@ -163,16 +171,17 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     Set-Location $TOOLS_DIR
 
     # Check for changes in packages.config and remove installed tools if true.
-    [string] $md5Hash = MD5HashFile($PACKAGES_CONFIG)
+    [string] $md5Hash = MD5HashFile $PACKAGES_CONFIG
     if((!(Test-Path $PACKAGES_CONFIG_MD5)) -Or
-      ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
+    ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
         Write-Verbose -Message "Missing or changed package.config hash..."
         Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
         Remove-Item -Recurse
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
+    
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$TOOLS_DIR`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occurred while restoring NuGet tools."
@@ -181,7 +190,7 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     {
         $md5Hash | Out-File $PACKAGES_CONFIG_MD5 -Encoding "ASCII"
     }
-    Write-Verbose -Message ($NuGetOutput | out-string)
+    Write-Verbose -Message ($NuGetOutput | Out-String)
 
     Pop-Location
 }
@@ -192,13 +201,13 @@ if (Test-Path $ADDINS_PACKAGES_CONFIG) {
     Set-Location $ADDINS_DIR
 
     Write-Verbose -Message "Restoring addins from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$ADDINS_DIR`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occurred while restoring NuGet addins."
     }
 
-    Write-Verbose -Message ($NuGetOutput | out-string)
+    Write-Verbose -Message ($NuGetOutput | Out-String)
 
     Pop-Location
 }
@@ -209,13 +218,13 @@ if (Test-Path $MODULES_PACKAGES_CONFIG) {
     Set-Location $MODULES_DIR
 
     Write-Verbose -Message "Restoring modules from NuGet..."
-    $NuGetOutput = Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
+    $NuGetOutput = Invoke-Expression "& $env:NUGET_EXE_INVOCATION install -ExcludeVersion -OutputDirectory `"$MODULES_DIR`""
 
     if ($LASTEXITCODE -ne 0) {
         Throw "An error occurred while restoring NuGet modules."
     }
 
-    Write-Verbose -Message ($NuGetOutput | out-string)
+    Write-Verbose -Message ($NuGetOutput | Out-String)
 
     Pop-Location
 }
@@ -225,6 +234,11 @@ if (!(Test-Path $CAKE_EXE)) {
     Throw "Could not find Cake.exe at $CAKE_EXE"
 }
 
+$CAKE_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
+    "mono `"$CAKE_EXE`""
+} else {
+    "`"$CAKE_EXE`""
+}
 
 
 # Build Cake arguments
@@ -238,5 +252,5 @@ $cakeArguments += $ScriptArgs
 
 # Start Cake
 Write-Host "Running build script..."
-&$CAKE_EXE $cakeArguments
+Invoke-Expression "& $CAKE_EXE_INVOCATION $($cakeArguments -join " ")"
 exit $LASTEXITCODE


### PR DESCRIPTION
This will allow the `build.ps1` to work on macOS & Linux using PowerShell Core. 

The script continues to work on Windows (both in Windows PowerShell and in PowerShell Core).

DISCLAIMER: this still relies on mono for macOS & Linux it doesn't rely on the `dotnet` global tool or any newer mechanism.