### PR TITLE
Introduce integration tests using pester test for build.ps1 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,14 @@ script:
   - mkdir tools/addins
   - echo -e "<?xml version=\"1.0\" encoding=\"utf-8\"?>\r\n<packages>\r\n    <package id=\"Cake.MicrosoftTeams\" version=\"0.7.0\" />\r\n</packages>" > ./tools/addins/packages.config
   - ./build.sh || exit 1
+  - echo "Test build.ps1 with pester tests"
+  - pwsh -command "Invoke-Expression .\tests\Tests.ps1"
   - ls -D -R
 os:
   - linux
+dist: xenial
+
+before_install:
+  - sudo snap install powershell --classic
+  - pwsh -command "Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted"
+  - pwsh -command "Install-Module -Name Pester"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,7 @@
 language: csharp
+env:
+  - CAKE_SETTINGS_SKIPVERIFICATION="true"
+  - CAKE_NUGET_USEINPROCESSCLIENT="true"
 script:
   - echo "Information(Context.Environment.Runtime.CakeVersion.ToString());" > build.cake
   - ./build.sh || exit 1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: csharp
 env:
-  - CAKE_SETTINGS_SKIPVERIFICATION="true"
-  - CAKE_NUGET_USEINPROCESSCLIENT="true"
+  - CAKE_SETTINGS_SKIPVERIFICATION="true" CAKE_NUGET_USEINPROCESSCLIENT="true"
 script:
   - echo "Information(Context.Environment.Runtime.CakeVersion.ToString());" > build.cake
   - ./build.sh || exit 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,145 +3,37 @@ version: 1.0.{build}
 image:
 - Visual Studio 2017
 - Ubuntu
-
-build_script:
+init:
 - ps: >-
+    Install-Module Pester -Force -Scope CurrentUser;
 
-    [int] $Result = 0;
+    pwsh -command "Install-Module Pester -Force -Scope CurrentUser";
 
-    # Temporarily skip verification and opt-in to new in-proc NuGet
+test_script:
+    - ps: >-
+        $ENV:CAKE_SETTINGS_SKIPVERIFICATION='true';
 
-    $ENV:CAKE_SETTINGS_SKIPVERIFICATION='true'
+        $ENV:CAKE_NUGET_USEINPROCESSCLIENT='true';
 
-    $ENV:CAKE_NUGET_USEINPROCESSCLIENT='true'
+        $testresultFolder = '.\tests\testresults';
 
-    'Creating Test Cake File'
+        "Execute tests for build.ps1 in powershell" | Write-Output
 
-    'Information("Test success: {0}", DateTime.Now);' > build.cake
+        Invoke-Pester .\tests\Execute-buid-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-buid-tests.xml') -PassThru;
 
+        if (-not $IsCoreCLR) {
 
-    'Testing with PowerShell Current'
+          Invoke-Pester .\tests\Execute-build-on-powershell-V2-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-build-on-powershell-V2-tests.xml') -PassThru;
 
-    $OutputA = ./build.ps1 2>&1
+        }
 
-    $Result = $LastExitCode
+        $webclient = (New-Object 'System.Net.WebClient');
 
-    $OutputA
+        foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
 
-    if ($Result -ne 0)
+          $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.Name));
 
-    {
-      'PowerShell 3 failed'
-
-      exit 3
-    }
-
-
-
-    if (-not $IsCoreCLR) {
-
-      'Testing with PowerShell V2'
-
-      $OutputB = PowerShell -Version 2.0 -File .\build.ps1 2>&1
-
-      $Result = $LastExitCode
-
-      $OutputB
-
-      if ($Result -ne 0)
-
-      {
-
-        'PowerShell 2 failed'
-
-        exit 2
-
-      }
-
-    }
-
-    'Creating Test Module Files'
-
-    New-Item -ItemType Directory ./tools/modules
-
-    "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.Chocolatey.Module"" version=""0.5.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/modules/packages.config
-
-    New-Item -ItemType Directory ./tools/addins
-
-    "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.MicrosoftTeams"" version=""0.7.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/addins/packages.config
-
-
-    'Testing with PowerShell Module & Addin restore'
-
-    $OutputC = ./build.ps1 2>&1
-
-    $Result = $LastExitCode
-
-    $OutputC
-
-    if ($Result -ne 0)
-
-    {
-
-      'PowerShell Module failed'
-
-      exit 2
-
-    }
-
-
-
-    'Validating StdErr'
-
-    $stdErrA = $OutputA | ?{ $_ -is [System.Management.Automation.ErrorRecord] }
-
-    $stdErrB = $OutputB | ?{ $_ -is [System.Management.Automation.ErrorRecord] }
-
-    $stdErrC = $OutputC | ?{ $_ -is [System.Management.Automation.ErrorRecord] }
-
-
-    $hasStdErrA = ($stdErrA | Measure-Object).Count -gt 0
-
-    $hasStdErrB = ($stdErrB | Measure-Object).Count -gt 0
-
-    $hasStdErrC = ($stdErrC | Measure-Object).Count -gt 0
-
-
-    if ($hasStdErrA)
-
-    {
-        'Std Error V3'
-
-        $stdErrA
-
-        exit 3
-    }
-
-
-    if ($hasStdErrB)
-
-    {
-        'Std Error V2'
-
-        $stdErrB
-
-        exit 2
-    }
-
-
-    if ($hasStdErrC)
-
-    {
-        'Module Error'
-
-        $stdErrC
-
-        exit 4
-    }
-
-
-    'No Issues found'
-
+        }
 
 artifacts:
   - path: '**\*'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,9 @@
 version: 1.0.{build}
 
+environment:
+  CAKE_SETTINGS_SKIPVERIFICATION: true
+  CAKE_NUGET_USEINPROCESSCLIENT: true
+
 image:
   - Visual Studio 2017
   - Ubuntu

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,11 @@ build_script:
 
 test_script:
   - ps: >-
-      Invoke-Expression .\tests\Tests.ps1
+      $testresultFolder = '.\tests\testresults';
 
-      Invoke-Expression .\tests\Upload-testresults.ps1
+      Invoke-Expression .\tests\Tests.ps1;
+
+      Invoke-Expression .\tests\Upload-testresults.ps1 -testresultFolder $testresultFolder;
 
 artifacts:
   - path: '**\*'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ test_script:
   - ps: >-
       $testresultFolder = '.\tests\testresults';
 
-      Invoke-Expression .\tests\Tests.ps1;
+      Invoke-Expression .\tests\Tests.ps1 -testresultFolder $testresultFolder;
 
       Invoke-Expression .\tests\Upload-testresults.ps1 -testresultFolder $testresultFolder;
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,9 +20,13 @@ test_script:
   - ps: >-
       $testresultFolder = '.\tests\testresults';
 
-      Invoke-Expression .\tests\Tests.ps1 -testresultFolder $testresultFolder;
+      $tests = '.\tests\Tests.ps1 -testresultFolder $testresultFolder;'
 
-      Invoke-Expression .\tests\Upload-testresults.ps1 -testresultFolder $testresultFolder;
+      Invoke-Expression $tests;
+
+      $upload = '.\tests\Upload-testresults.ps1 -testresultFolder $testresultFolder;'
+
+      Invoke-Expression $upload;
 
 artifacts:
   - path: '**\*'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,35 +13,7 @@ build_script:
     "nothing to build." | Write-Output
 test_script:
   - ps: >-
-      $ENV:CAKE_SETTINGS_SKIPVERIFICATION='true';
-
-      $ENV:CAKE_NUGET_USEINPROCESSCLIENT='true';
-
-      $testresultFolder = '.\tests\testresults';
-      if (!(Test-Path -Path $testresultFolder)) {
-
-        New-Item -Type Directory -Path $testresultFolder -Force
-
-      }
-
-      "Execute tests for build.ps1 in powershell" | Write-Output
-
-      Invoke-Pester .\tests\Execute-buid-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-buid-tests.xml') -PassThru;
-
-      if (-not $IsCoreCLR) {
-
-        Invoke-Pester .\tests\Execute-build-on-powershell-V2-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-build-on-powershell-V2-tests.xml') -PassThru;
-
-      }
-
-      $webclient = (New-Object 'System.Net.WebClient');
-
-      foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
-
-        $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.Name));
-
-      }
-
+    & .\tests\Tests.ps1
 artifacts:
   - path: '**\*'
     name: Resources

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,6 +18,11 @@ test_script:
       $ENV:CAKE_NUGET_USEINPROCESSCLIENT='true';
 
       $testresultFolder = '.\tests\testresults';
+      if (!(Test-Path -Path $testresultFolder)) {
+
+        New-Item -Type Directory -Path $testresultFolder -Force
+
+      }
 
       "Execute tests for build.ps1 in powershell" | Write-Output
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,39 +1,41 @@
 version: 1.0.{build}
 
 image:
-- Visual Studio 2017
-- Ubuntu
+  - Visual Studio 2017
+  - Ubuntu
 init:
-- ps: >-
-    Install-Module Pester -Force -Scope CurrentUser;
+  - ps: >-
+      Install-Module Pester -Force -Scope CurrentUser;
 
-    pwsh -command "Install-Module Pester -Force -Scope CurrentUser";
-
+      pwsh -command "Install-Module Pester -Force -Scope CurrentUser";
+build_script:
+  -ps: >-
+    "nothing to build." | Write-Output
 test_script:
-    - ps: >-
-        $ENV:CAKE_SETTINGS_SKIPVERIFICATION='true';
+  - ps: >-
+      $ENV:CAKE_SETTINGS_SKIPVERIFICATION='true';
 
-        $ENV:CAKE_NUGET_USEINPROCESSCLIENT='true';
+      $ENV:CAKE_NUGET_USEINPROCESSCLIENT='true';
 
-        $testresultFolder = '.\tests\testresults';
+      $testresultFolder = '.\tests\testresults';
 
-        "Execute tests for build.ps1 in powershell" | Write-Output
+      "Execute tests for build.ps1 in powershell" | Write-Output
 
-        Invoke-Pester .\tests\Execute-buid-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-buid-tests.xml') -PassThru;
+      Invoke-Pester .\tests\Execute-buid-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-buid-tests.xml') -PassThru;
 
-        if (-not $IsCoreCLR) {
+      if (-not $IsCoreCLR) {
 
-          Invoke-Pester .\tests\Execute-build-on-powershell-V2-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-build-on-powershell-V2-tests.xml') -PassThru;
+        Invoke-Pester .\tests\Execute-build-on-powershell-V2-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-build-on-powershell-V2-tests.xml') -PassThru;
 
-        }
+      }
 
-        $webclient = (New-Object 'System.Net.WebClient');
+      $webclient = (New-Object 'System.Net.WebClient');
 
-        foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
+      foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
 
-          $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.Name));
+        $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.Name));
 
-        }
+      }
 
 artifacts:
   - path: '**\*'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,8 @@ test_script:
   - ps: >-
       Invoke-Expression .\tests\Tests.ps1
 
+      Invoke-Expression .\tests\Upload-testresults.ps1
+
 artifacts:
   - path: '**\*'
     name: Resources

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,8 +9,9 @@ init:
 
       pwsh -command "Install-Module Pester -Force -Scope CurrentUser";
 build_script:
-  -ps: >-
+  - ps: >-
     "nothing to build." | Write-Output
+
 test_script:
   - ps: >-
       Invoke-Expression .\tests\Tests.ps1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,7 +10,7 @@ init:
       pwsh -command "Install-Module Pester -Force -Scope CurrentUser";
 build_script:
   - ps: >-
-    "nothing to build." | Write-Output
+      Write-Output "nothing to build."
 
 test_script:
   - ps: >-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,8 @@ build_script:
     "nothing to build." | Write-Output
 test_script:
   - ps: >-
-    & .\tests\Tests.ps1
+      Invoke-Expression .\tests\Tests.ps1
+
 artifacts:
   - path: '**\*'
     name: Resources

--- a/tests/Execute-buid-tests.ps1
+++ b/tests/Execute-buid-tests.ps1
@@ -12,9 +12,6 @@ Describe 'Execute build.ps1 file successfully' {
         $normalErrorAction = $Global:ErrorActionPreference
         $Global:ErrorActionPreference = "Stop"
 
-        # Temporarily skip verification and opt-in to new in-proc NuGet
-        $ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true'
-        $ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true'
         'Creating Test Cake File' | Write-Output
         'Information("Test success: {0}", DateTime.Now);' > build.cake
     }

--- a/tests/Execute-buid-tests.ps1
+++ b/tests/Execute-buid-tests.ps1
@@ -1,0 +1,40 @@
+Describe 'Execute build.ps1 file successfully' {
+    $testPath;
+    $normalErrorAction;
+    BeforeEach {
+        $name = [System.IO.Path]::GetRandomFileName()
+        $path = (Join-Path $PSScriptRoot $name)
+        New-Item -ItemType Directory -Path $path
+        $testPath = $path
+        Copy-Item -Path .\build.ps1 -Destination $testPath
+        Push-Location
+        Set-Location $testPath
+        $normalErrorAction = $Global:ErrorActionPreference
+        $Global:ErrorActionPreference = "Stop"
+
+        # Temporarily skip verification and opt-in to new in-proc NuGet
+        $ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true'
+        $ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true'
+        'Creating Test Cake File' | Write-Output
+        'Information("Test success: {0}", DateTime.Now);' > build.cake
+    }
+    AfterEach {
+        $Global:ErrorActionPreference = $normalErrorAction
+        Pop-Location
+        Remove-Item -Recurse $testPath -Force
+    }
+    It "Execute simple build.cake" {
+        'Testing with PowerShell Current' | Write-Output
+        & ./build.ps1
+        $LastExitCode | Should -Be 0
+    }
+    It "Execute build.cake with addins and modules package.config" {
+        New-Item -ItemType Directory ./tools/modules
+        "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.Chocolatey.Module"" version=""0.5.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/modules/packages.config
+        New-Item -ItemType Directory ./tools/addins
+        "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.MicrosoftTeams"" version=""0.7.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/addins/packages.config
+        'Testing with PowerShell Module & Addin restore' | Write-Output
+        & ./build.ps1
+        $LastExitCode | Should -Be 0
+    }
+}

--- a/tests/Execute-build-on-powershell-V2-tests.ps1
+++ b/tests/Execute-build-on-powershell-V2-tests.ps1
@@ -1,0 +1,40 @@
+Describe 'Execute build.ps1 file successfully on Powershell V2' {
+    $testPath;
+    $normalErrorAction;
+    BeforeEach {
+        $name = [System.IO.Path]::GetRandomFileName()
+        $path = (Join-Path $PSScriptRoot $name)
+        New-Item -ItemType Directory -Path $path
+        $testPath = $path
+        Copy-Item -Path .\build.ps1 -Destination $testPath
+        Push-Location
+        Set-Location $testPath
+        $normalErrorAction = $Global:ErrorActionPreference
+        $Global:ErrorActionPreference = "Stop"
+
+        # Temporarily skip verification and opt-in to new in-proc NuGet
+        $ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true'
+        $ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true'
+        'Creating Test Cake File' | Write-Output
+        'Information("Test success: {0}", DateTime.Now);' > build.cake
+    }
+    AfterEach {
+        $Global:ErrorActionPreference = $normalErrorAction
+        Pop-Location
+        Remove-Item -Recurse $testPath -Force
+    }
+    It "Execute simple build.cake" {
+        'Testing with PowerShell Current' | Write-Output
+        & PowerShell -Version 2.0 -File .\build.ps1
+        $LastExitCode | Should -Be 0
+    }
+    It "Execute build.cake with addins and modules package.config" {
+        New-Item -ItemType Directory ./tools/modules
+        "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.Chocolatey.Module"" version=""0.5.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/modules/packages.config
+        New-Item -ItemType Directory ./tools/addins
+        "<?xml version=""1.0"" encoding=""utf-8""?>`r`n<packages>`r`n    <package id=""Cake.MicrosoftTeams"" version=""0.7.0"" />`r`n</packages>" | Out-File -Encoding utf8 -FilePath ./tools/addins/packages.config
+        'Testing with PowerShell Module & Addin restore' | Write-Output
+        & PowerShell -Version 2.0 -File .\build.ps1
+        $LastExitCode | Should -Be 0
+    }
+}

--- a/tests/Execute-build-on-powershell-V2-tests.ps1
+++ b/tests/Execute-build-on-powershell-V2-tests.ps1
@@ -12,9 +12,6 @@ Describe 'Execute build.ps1 file successfully on Powershell V2' {
         $normalErrorAction = $Global:ErrorActionPreference
         $Global:ErrorActionPreference = "Stop"
 
-        # Temporarily skip verification and opt-in to new in-proc NuGet
-        $ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true'
-        $ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true'
         'Creating Test Cake File' | Write-Output
         'Information("Test success: {0}", DateTime.Now);' > build.cake
     }

--- a/tests/Tests.ps1
+++ b/tests/Tests.ps1
@@ -1,0 +1,21 @@
+$ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true';
+$ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true';
+
+$testresultFolder = '.\tests\testresults';
+if (!(Test-Path -Path $testresultFolder)) {
+    New-Item -Type Directory -Path $testresultFolder -Force
+}
+
+"Execute tests for build.ps1 in powershell" | Write-Output
+
+Invoke-Pester .\tests\Execute-buid-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-buid-tests.xml') -PassThru;
+
+if (-not $IsCoreCLR) {
+    Invoke-Pester .\tests\Execute-build-on-powershell-V2-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-build-on-powershell-V2-tests.xml') -PassThru;
+}
+
+$webclient = (New-Object 'System.Net.WebClient');
+
+foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
+    $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.FullName));
+}

--- a/tests/Tests.ps1
+++ b/tests/Tests.ps1
@@ -1,6 +1,3 @@
-$ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true';
-$ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true';
-
 $testresultFolder = '.\tests\testresults';
 if (-not (Test-Path -Path $testresultFolder)) {
     New-Item -Type Directory -Path $testresultFolder -Force
@@ -17,5 +14,6 @@ if (-not $IsCoreCLR) {
 $webclient = (New-Object 'System.Net.WebClient');
 
 foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
+    "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)" | Write-Output
     $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.FullName));
 }

--- a/tests/Tests.ps1
+++ b/tests/Tests.ps1
@@ -2,7 +2,7 @@ $ENV:CAKE_SETTINGS_SKIPVERIFICATION = 'true';
 $ENV:CAKE_NUGET_USEINPROCESSCLIENT = 'true';
 
 $testresultFolder = '.\tests\testresults';
-if (!(Test-Path -Path $testresultFolder)) {
+if (-not (Test-Path -Path $testresultFolder)) {
     New-Item -Type Directory -Path $testresultFolder -Force
 }
 

--- a/tests/Tests.ps1
+++ b/tests/Tests.ps1
@@ -10,10 +10,3 @@ Invoke-Pester .\tests\Execute-buid-tests.ps1 -OutputFormat NUnitXml -OutputFile 
 if (-not $IsCoreCLR) {
     Invoke-Pester .\tests\Execute-build-on-powershell-V2-tests.ps1 -OutputFormat NUnitXml -OutputFile (Join-Path -Path $testresultFolder -ChildPath 'Execute-build-on-powershell-V2-tests.xml') -PassThru;
 }
-
-$webclient = (New-Object 'System.Net.WebClient');
-
-foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
-    "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)" | Write-Output
-    $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.FullName));
-}

--- a/tests/Tests.ps1
+++ b/tests/Tests.ps1
@@ -1,4 +1,7 @@
-$testresultFolder = '.\tests\testresults';
+param (
+    [string]$testresultFolder
+)
+
 if (-not (Test-Path -Path $testresultFolder)) {
     New-Item -Type Directory -Path $testresultFolder -Force
 }

--- a/tests/Upload-testresults.ps1
+++ b/tests/Upload-testresults.ps1
@@ -1,0 +1,6 @@
+$webclient = (New-Object 'System.Net.WebClient');
+
+foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
+    "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)" | Write-Output
+    $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.FullName));
+}

--- a/tests/Upload-testresults.ps1
+++ b/tests/Upload-testresults.ps1
@@ -1,6 +1,9 @@
+param(
+    [string]$testresultFolder
+)
+
 $webclient = (New-Object 'System.Net.WebClient');
 
 foreach ($testResult in  (Get-ChildItem -Path $testresultFolder)) {
-    "https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)" | Write-Output
     $webclient.UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResult.FullName));
 }


### PR DESCRIPTION
## Summary
Changed script for appveyor and travis ci to execute tests for build.ps1 as pester tests

### Appveyor
Changed the whole build file and moved all tests to the test section and upload results into the tests section of Appveyor jobs

### Travis CI
build.sh stays as it is. Added Invoke-Pester tests to get executed on pwsh and test the build.ps1 file.

### TODOs
May some more sophisticated tests are needed.
* only the execution of the script is tested no errors are expected (using global setting `$Global:ErrorActionPreference = "Stop"` and last exit code)