### PR TITLE
Support for targets containing special characters

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -243,7 +243,7 @@ $CAKE_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
 
 # Build Cake arguments
 $cakeArguments = @("$Script");
-if ($Target) { $cakeArguments += "-target=""$Target""" }
+if ($Target) { $cakeArguments += "-target=`"$Target`"" }
 if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
 if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
 if ($ShowDescription) { $cakeArguments += "-showdescription" }

--- a/build.ps1
+++ b/build.ps1
@@ -243,7 +243,7 @@ $CAKE_EXE_INVOCATION = if ($IsLinux -or $IsMacOS) {
 
 # Build Cake arguments
 $cakeArguments = @("$Script");
-if ($Target) { $cakeArguments += "-target=$Target" }
+if ($Target) { $cakeArguments += "-target=""$Target""" }
 if ($Configuration) { $cakeArguments += "-configuration=$Configuration" }
 if ($Verbosity) { $cakeArguments += "-verbosity=$Verbosity" }
 if ($ShowDescription) { $cakeArguments += "-showdescription" }


### PR DESCRIPTION
Targets now survives through build.ps1, even if they contain dots and the like.