### PR TITLE
Force was needed here to properly clean up the folder

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -176,7 +176,7 @@ if(-Not $SkipToolPackageRestore.IsPresent) {
     ($md5Hash -ne (Get-Content $PACKAGES_CONFIG_MD5 ))) {
         Write-Verbose -Message "Missing or changed package.config hash..."
         Get-ChildItem -Exclude packages.config,nuget.exe,Cake.Bakery |
-        Remove-Item -Recurse
+        Remove-Item -Recurse -Force
     }
 
     Write-Verbose -Message "Restoring tools from NuGet..."


### PR DESCRIPTION
Was attempting to move https://github.com/OmniSharp/csharp-language-server-protocol over to the new `build.ps1` and noticed that this throws a bunch of:

```
Remove-Item : You do not have sufficient access rights to perform this operation or the item is hidden, system, or read only.
At /Users/tyleonha/Code/CSharp/csharp-language-server-protocol/build.ps1:179 char:9
+         Remove-Item -Recurse
+         ~~~~~~~~~~~~~~~~~~~~
+ CategoryInfo          : PermissionDenied: (/Users/tyleonha/Cod….9.3/.signature.p7s:FileInfo) [Remove-Item], IOException
+ FullyQualifiedErrorId : RemoveFileSystemItemUnAuthorizedAccess,Microsoft.PowerShell.Commands.RemoveItemCommand
```

when trying to remove things from the tools dir. Adding a `-Force` so that this clean up actually works properly.