### PR TITLE
Set CAKE_PATHS_TOOLS environment variable in build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -118,6 +118,8 @@ $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
 
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
     Write-Verbose -Message "Creating tools directory..."


### PR DESCRIPTION
If you changed `$TOOLS_DIR` into something else then addins would still be installed in the `tools` directory. Setting this environment variable makes sure that Cake.exe also uses the right tools directory.
