### PR TITLE
Set CAKE_PATHS_* environment variable in build.sh and build.ps1

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -118,6 +118,8 @@ $PACKAGES_CONFIG_MD5 = Join-Path $TOOLS_DIR "packages.config.md5sum"
 $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
 
+$env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {
     Write-Verbose -Message "Creating tools directory..."

--- a/build.ps1
+++ b/build.ps1
@@ -119,6 +119,8 @@ $ADDINS_PACKAGES_CONFIG = Join-Path $ADDINS_DIR "packages.config"
 $MODULES_PACKAGES_CONFIG = Join-Path $MODULES_DIR "packages.config"
 
 $env:CAKE_PATHS_TOOLS = $TOOLS_DIR
+$env:CAKE_PATHS_ADDINS = $ADDINS_DIR
+$env:CAKE_PATHS_MODULES = $MODULES_DIR
 
 # Make sure tools folder exists
 if ((Test-Path $PSScriptRoot) -and !(Test-Path $TOOLS_DIR)) {

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,10 @@ PACKAGES_CONFIG_MD5=$TOOLS_DIR/packages.config.md5sum
 ADDINS_PACKAGES_CONFIG=$ADDINS_DIR/packages.config
 MODULES_PACKAGES_CONFIG=$MODULES_DIR/packages.config
 
+export CAKE_PATHS_TOOLS=$TOOLS_DIR
+export CAKE_PATHS_ADDINS=$ADDINS_DIR
+export CAKE_PATHS_MODULES=$MODULES_DIR
+
 # Define md5sum or md5 depending on Linux/OSX
 MD5_EXE=
 if [[ "$(uname -s)" == "Darwin" ]]; then


### PR DESCRIPTION
If you changed $TOOLS_DIR into something else then addins would still be installed in the tools directory. Setting this environment variable makes sure that Cake.exe also uses the right tools directory.