### PR TITLE
Bootstrappers takes default script from within its own folder

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -37,7 +37,7 @@ https://cakebuild.net
 
 [CmdletBinding()]
 Param(
-    [string]$Script = "build.cake",
+    [string]$Script,
     [string]$Target,
     [string]$Configuration,
     [ValidateSet("Quiet", "Minimal", "Normal", "Verbose", "Diagnostic")]
@@ -107,6 +107,9 @@ if(!$PSScriptRoot){
     $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 }
 
+if(!$Script){
+    $Script = Join-Path $PSScriptRoot "build.cake"
+}
 $TOOLS_DIR = Join-Path $PSScriptRoot "tools"
 $ADDINS_DIR = Join-Path $TOOLS_DIR "Addins"
 $MODULES_DIR = Join-Path $TOOLS_DIR "Modules"

--- a/build.sh
+++ b/build.sh
@@ -27,7 +27,7 @@ else
 fi
 
 # Define default arguments.
-SCRIPT="build.cake"
+SCRIPT=$SCRIPT_DIR/build.cake
 CAKE_ARGUMENTS=()
 
 # Parse arguments.


### PR DESCRIPTION
The changes allows to call build.ps1 or build.sh from any folder and cake will take the build.cake script found in the same folder as the bootstrapper is located.

Fixes #19