### PR TITLE
Fix travis build error for snap install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ os:
 dist: xenial
 
 before_install:
+  - sudo snap install core
   - sudo snap install powershell --classic
   - pwsh -command "Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted"
   - pwsh -command "Install-Module -Name Pester"

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,4 @@ before_install:
   - sudo snap install powershell --classic
   - pwsh -command "Set-PSRepository -Name "PSGallery" -InstallationPolicy Trusted"
   - pwsh -command "Install-Module -Name Pester"
+  - cp dotnet-framework/build.sh build.sh


### PR DESCRIPTION
The latest travis build fails with the following error,
https://travis-ci.org/github/cake-build/resources/jobs/741243741:

  $ sudo snap install powershell --classic
  error: cannot perform the following tasks:
  - Mount snap "powershell" (137) (snap "powershell" assumes unsupported features: command-chain (try to update snapd and refresh the core snap))
  The command "sudo snap install powershell --classic" failed and exited with 1 during .
  Your build has been stopped.

According to https://forum.snapcraft.io/t/installing-snap-on-debian/6742:

  Note: some snaps require new snapd features and will show an error
  such as snap "lxd" assumes unsupported features" during install. You
  can solve this issue by making sure the core snap is installed (snap
  install core) and it’s the latest version (snap refresh core).

and the error message itself also hints to this.