### PR TITLE
Update build.sh to accept quoted parameters

### DIFF
--- a/dotnet-tool/build.sh
+++ b/dotnet-tool/build.sh
@@ -9,4 +9,4 @@ export DOTNET_NOLOGO=1
 
 dotnet tool restore
 
-dotnet cake $@
+dotnet cake "$@"


### PR DESCRIPTION
We get into errors when using origianl build.sh from
https://cakebuild.net/docs/running-builds/runners/dotnet-tool#getting-the-bootstrapper

build.cake
```
Task("TestArg").Does(() => { Information(Argument<string>("quoted")); });
```
Running: `$ ./build.sh --target=TestArg --quoted="test test"`

Before fix:
```
Restore was successful.
+ dotnet cake --target=TestArg --quoted=test test
Error: Bootstrapping failed for '/home/rwartalski/esky-hapi-service/test'.
test, line #0: Could not find script '/home/rwartalski/esky-hapi-service/test'.
```

After fix:
```
========================================
TestArg
========================================
test test
```