### PR TITLE
(maint) Add missing configuration values

### DIFF
--- a/cake.config
+++ b/cake.config
@@ -15,3 +15,5 @@ Cache=./tools/Cache
 [Settings]
 SkipVerification=false
 EnableScriptCache=false
+ShowProcessCommandLine=false
+UseSpectreConsoleForConsoleOutput=false


### PR DESCRIPTION
Add default configuration value for console output and show the process command line.